### PR TITLE
Changed type of channel announcements can be sent to

### DIFF
--- a/src/interactions/sendAnnouncement.ts
+++ b/src/interactions/sendAnnouncement.ts
@@ -11,8 +11,6 @@ export default {
     },
     async execute(interaction: ButtonInteraction, announcement_id: string) {
         const channel = interaction.client.channels.cache.get(announcement_channel_id);
-        console.log(channel instanceof TextChannel)
-        console.log(channel)
         
         if (!(channel instanceof TextChannel || channel instanceof NewsChannel)) {
             console.warn("Unable To Retrieve Usable Announcement Channel")

--- a/src/interactions/sendAnnouncement.ts
+++ b/src/interactions/sendAnnouncement.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, TextChannel } from 'discord.js';
+import { ButtonInteraction, TextChannel, NewsChannel } from 'discord.js';
 import { encodeCustomId } from './utils';
 import { announcement_channel_id } from '../utils/config';
 import { createAnnouncement } from '../utils/templates';
@@ -11,8 +11,10 @@ export default {
     },
     async execute(interaction: ButtonInteraction, announcement_id: string) {
         const channel = interaction.client.channels.cache.get(announcement_channel_id);
+        console.log(channel instanceof TextChannel)
+        console.log(channel)
         
-        if (!(channel instanceof TextChannel)) {
+        if (!(channel instanceof TextChannel || channel instanceof NewsChannel)) {
             console.warn("Unable To Retrieve Usable Announcement Channel")
             await interaction.reply({
                 content: ":x: Could Not Retrieve Announcement Channel!",


### PR DESCRIPTION
In the main server, the announcement channel is not of type `TextChannel` but is of type `NewsChannel`. Now added that the announcement can be sent to a news channel additionally